### PR TITLE
Add support for newer versions of Firefox

### DIFF
--- a/avendesora/title.py
+++ b/avendesora/title.py
@@ -120,7 +120,7 @@ class AddURLToWindowTitle(Title):
     # This matches the default pattern produced by AddURLToWindowTitle in
     # Firefox, though sometimes it outputs the host, and sometimes it does not.
     PATTERN = re.compile(
-        r'\A{title}- {url} - (?:{host} - )?{browser}\Z'.format(**REGEX_COMPONENTS)
+        r'\A{title}- {url} [-—] (?:{host} [-—] )?{browser}\Z'.format(**REGEX_COMPONENTS)
     )
     PRIORITY = 1
 


### PR DESCRIPTION
Firefox recently changed their titles from a regular dash (-) to an em-dash (—). Because of this, Avendesora no longer filled in website passwords. This commit amends it to accept both.